### PR TITLE
feat: update AXe to v1.2.1 and expose new capabilities

### DIFF
--- a/lib/orchard/config.ex
+++ b/lib/orchard/config.ex
@@ -8,7 +8,7 @@ defmodule Orchard.Config do
   @external_resource "priv/axe/versions.json"
   @versions File.read!("priv/axe/versions.json") |> Jason.decode!()
 
-  @default_version "1.0.0"
+  @default_version "1.2.1"
 
   @doc """
   Returns the default AXe version.

--- a/lib/orchard/simulator.ex
+++ b/lib/orchard/simulator.ex
@@ -305,6 +305,190 @@ defmodule Orchard.Simulator do
   end
 
   @doc """
+  Performs a tap on an element with the given accessibility ID.
+
+  This is more reliable than coordinate-based taps as it automatically
+  finds the element regardless of screen position.
+
+  Available since AXe 1.2.0.
+
+  ## Options
+
+  - `:pre_delay` - Delay in seconds before the tap (default: none)
+  - `:post_delay` - Delay in seconds after the tap (default: none)
+
+  ## Examples
+
+      iex> Orchard.Simulator.tap_accessibility_id(simulator, "loginButton")
+      :ok
+
+      iex> Orchard.Simulator.tap_accessibility_id(simulator, "submitBtn", pre_delay: 0.5)
+      :ok
+  """
+  @spec tap_accessibility_id(t(), String.t(), keyword()) :: :ok | {:error, String.t()}
+  def tap_accessibility_id(%__MODULE__{udid: udid}, accessibility_id, opts \\ []) do
+    case SimulatorSupervisor.find_simulator(udid) do
+      {:ok, _pid} ->
+        SimulatorServer.tap_accessibility_id(udid, accessibility_id, opts)
+
+      {:error, :not_found} ->
+        {:error, "Simulator server not running"}
+    end
+  end
+
+  @doc """
+  Performs a tap on an element with the given accessibility label.
+
+  This is more reliable than coordinate-based taps as it automatically
+  finds the element regardless of screen position.
+
+  Available since AXe 1.2.0.
+
+  ## Options
+
+  - `:pre_delay` - Delay in seconds before the tap (default: none)
+  - `:post_delay` - Delay in seconds after the tap (default: none)
+
+  ## Examples
+
+      iex> Orchard.Simulator.tap_label(simulator, "Sign In")
+      :ok
+
+      iex> Orchard.Simulator.tap_label(simulator, "Submit", post_delay: 1.0)
+      :ok
+  """
+  @spec tap_label(t(), String.t(), keyword()) :: :ok | {:error, String.t()}
+  def tap_label(%__MODULE__{udid: udid}, label, opts \\ []) do
+    case SimulatorSupervisor.find_simulator(udid) do
+      {:ok, _pid} ->
+        SimulatorServer.tap_label(udid, label, opts)
+
+      {:error, :not_found} ->
+        {:error, "Simulator server not running"}
+    end
+  end
+
+  @doc """
+  Performs a swipe gesture on the simulator.
+
+  ## Options
+
+  - `:duration` - Duration of the swipe in seconds (default: system default)
+  - `:delta` - Step size for the swipe motion (default: system default)
+  - `:pre_delay` - Delay in seconds before the swipe (default: none)
+  - `:post_delay` - Delay in seconds after the swipe (default: none)
+
+  ## Examples
+
+      iex> Orchard.Simulator.swipe(simulator, 100, 500, 100, 100)
+      :ok
+
+      iex> Orchard.Simulator.swipe(simulator, 50, 500, 350, 500, duration: 2.0)
+      :ok
+  """
+  @spec swipe(t(), number(), number(), number(), number(), keyword()) :: :ok | {:error, String.t()}
+  def swipe(%__MODULE__{udid: udid}, start_x, start_y, end_x, end_y, opts \\ []) do
+    case SimulatorSupervisor.find_simulator(udid) do
+      {:ok, _pid} ->
+        SimulatorServer.swipe(udid, start_x, start_y, end_x, end_y, opts)
+
+      {:error, :not_found} ->
+        {:error, "Simulator server not running"}
+    end
+  end
+
+  @doc """
+  Performs a preset gesture on the simulator.
+
+  ## Available gestures
+
+  - `:scroll_up` - Scroll up gesture
+  - `:scroll_down` - Scroll down gesture
+  - `:scroll_left` - Scroll left gesture
+  - `:scroll_right` - Scroll right gesture
+  - `:swipe_from_left_edge` - Swipe from left edge (back navigation)
+  - `:swipe_from_right_edge` - Swipe from right edge
+  - `:swipe_from_top_edge` - Swipe from top edge (notification center)
+  - `:swipe_from_bottom_edge` - Swipe from bottom edge (control center/home)
+
+  ## Options
+
+  - `:screen_width` - Custom screen width (default: auto-detected)
+  - `:screen_height` - Custom screen height (default: auto-detected)
+  - `:pre_delay` - Delay in seconds before the gesture (default: none)
+  - `:post_delay` - Delay in seconds after the gesture (default: none)
+
+  ## Examples
+
+      iex> Orchard.Simulator.gesture(simulator, :scroll_down)
+      :ok
+
+      iex> Orchard.Simulator.gesture(simulator, :swipe_from_left_edge)
+      :ok
+  """
+  @spec gesture(t(), atom() | String.t(), keyword()) :: :ok | {:error, String.t()}
+  def gesture(%__MODULE__{udid: udid}, gesture_name, opts \\ []) do
+    case SimulatorSupervisor.find_simulator(udid) do
+      {:ok, _pid} ->
+        # Convert atom to string with dashes
+        gesture_str =
+          gesture_name
+          |> to_string()
+          |> String.replace("_", "-")
+
+        SimulatorServer.gesture(udid, gesture_str, opts)
+
+      {:error, :not_found} ->
+        {:error, "Simulator server not running"}
+    end
+  end
+
+  @doc """
+  Simulates pressing a hardware button on the simulator.
+
+  ## Available buttons
+
+  - `:home` - Home button
+  - `:lock` - Lock/power button
+  - `:side_button` - Side button (iPhone X and later)
+  - `:siri` - Siri button
+  - `:apple_pay` - Apple Pay button
+
+  ## Options
+
+  - `:duration` - Button press duration in seconds (useful for lock button)
+  - `:pre_delay` - Delay in seconds before the button press (default: none)
+  - `:post_delay` - Delay in seconds after the button press (default: none)
+
+  ## Examples
+
+      iex> Orchard.Simulator.button(simulator, :home)
+      :ok
+
+      iex> Orchard.Simulator.button(simulator, :lock, duration: 2.0)
+      :ok
+
+      iex> Orchard.Simulator.button(simulator, :siri)
+      :ok
+  """
+  @spec button(t(), atom() | String.t(), keyword()) :: :ok | {:error, String.t()}
+  def button(%__MODULE__{udid: udid}, button_name, opts \\ []) do
+    case SimulatorSupervisor.find_simulator(udid) do
+      {:ok, _pid} ->
+        # Convert atom to string with dashes
+        button_str =
+          button_name
+          |> to_string()
+          |> String.replace("_", "-")
+
+        SimulatorServer.button(udid, button_str, opts)
+
+      {:error, :not_found} ->
+        {:error, "Simulator server not running"}
+    end
+  end
+
+  @doc """
   Gets UI hierarchy description from AXe
   """
   def describe_ui(%__MODULE__{udid: udid}) do
@@ -341,6 +525,67 @@ defmodule Orchard.Simulator do
   """
   def capture_video(%__MODULE__{udid: udid}, opts \\ []) do
     Orchard.SimulatorStream.start_screenshot_stream(udid, opts)
+  end
+
+  @doc """
+  Starts video streaming using AXe's native stream-video command.
+
+  Available since AXe 1.1.0. This provides high-performance video streaming
+  with multiple output formats.
+
+  ## Options
+
+  - `:fps` - Frames per second, 1-30 (default: 10)
+  - `:format` - Output format: `:mjpeg`, `:raw`, `:ffmpeg`, `:bgra` (default: `:mjpeg`)
+  - `:output` - Output file path (optional, streams to stdout if not specified)
+
+  ## Formats
+
+  - `:mjpeg` - MJPEG format, suitable for direct playback
+  - `:raw` - Raw JPEG frames
+  - `:ffmpeg` - FFmpeg-compatible output for piping to ffmpeg
+  - `:bgra` - Legacy BGRA pixel format
+
+  ## Examples
+
+      iex> {:ok, stream} = Orchard.Simulator.stream_video(simulator, fps: 15, output: "stream.mjpeg")
+      iex> Orchard.Simulator.stop_video_capture(stream)
+      :ok
+
+      iex> {:ok, stream} = Orchard.Simulator.stream_video(simulator, format: :ffmpeg, fps: 30)
+      :ok
+  """
+  @spec stream_video(t(), keyword()) :: {:ok, map()} | {:error, String.t()}
+  def stream_video(%__MODULE__{udid: udid}, opts \\ []) do
+    Orchard.SimulatorStream.start_axe_stream(udid, opts)
+  end
+
+  @doc """
+  Records video directly to MP4 using AXe's native record-video command.
+
+  Available since AXe 1.1.0. This provides direct H.264 encoding to MP4 files
+  with configurable quality and scaling options.
+
+  ## Options
+
+  - `:fps` - Frames per second (default: 15)
+  - `:quality` - JPEG quality 1-100 (default: system default)
+  - `:scale` - Scale factor 0.0-1.0 (default: 1.0, full resolution)
+
+  ## Examples
+
+      iex> {:ok, recording} = Orchard.Simulator.record_video_axe(simulator, "output.mp4", fps: 20)
+      iex> Process.sleep(5000)  # Record for 5 seconds
+      iex> Orchard.Simulator.stop_video_capture(recording)
+      :ok
+
+      iex> {:ok, recording} = Orchard.Simulator.record_video_axe(simulator, "output.mp4",
+      ...>   fps: 10, quality: 60, scale: 0.5)
+      :ok
+  """
+  @spec record_video_axe(t(), String.t(), keyword()) :: {:ok, map()} | {:error, String.t()}
+  def record_video_axe(%__MODULE__{udid: udid}, output_path, opts \\ []) do
+    Orchard.SimulatorStream.start_axe_recording(udid, output_path, opts)
   end
 
   @doc """

--- a/lib/orchard/simulator.ex
+++ b/lib/orchard/simulator.ex
@@ -386,7 +386,8 @@ defmodule Orchard.Simulator do
       iex> Orchard.Simulator.swipe(simulator, 50, 500, 350, 500, duration: 2.0)
       :ok
   """
-  @spec swipe(t(), number(), number(), number(), number(), keyword()) :: :ok | {:error, String.t()}
+  @spec swipe(t(), number(), number(), number(), number(), keyword()) ::
+          :ok | {:error, String.t()}
   def swipe(%__MODULE__{udid: udid}, start_x, start_y, end_x, end_y, opts \\ []) do
     case SimulatorSupervisor.find_simulator(udid) do
       {:ok, _pid} ->

--- a/lib/orchard/simulator_server.ex
+++ b/lib/orchard/simulator_server.ex
@@ -93,6 +93,41 @@ defmodule Orchard.SimulatorServer do
     GenServer.call(via_tuple(udid), {:type_text, text})
   end
 
+  @doc """
+  Performs a tap at an element with the given accessibility ID.
+  """
+  def tap_accessibility_id(udid, accessibility_id, opts \\ []) do
+    GenServer.call(via_tuple(udid), {:tap_accessibility_id, accessibility_id, opts})
+  end
+
+  @doc """
+  Performs a tap at an element with the given label.
+  """
+  def tap_label(udid, label, opts \\ []) do
+    GenServer.call(via_tuple(udid), {:tap_label, label, opts})
+  end
+
+  @doc """
+  Performs a swipe gesture on the simulator.
+  """
+  def swipe(udid, start_x, start_y, end_x, end_y, opts \\ []) do
+    GenServer.call(via_tuple(udid), {:swipe, start_x, start_y, end_x, end_y, opts})
+  end
+
+  @doc """
+  Performs a preset gesture on the simulator.
+  """
+  def gesture(udid, gesture_name, opts \\ []) do
+    GenServer.call(via_tuple(udid), {:gesture, gesture_name, opts})
+  end
+
+  @doc """
+  Simulates pressing a hardware button on the simulator.
+  """
+  def button(udid, button_name, opts \\ []) do
+    GenServer.call(via_tuple(udid), {:button, button_name, opts})
+  end
+
   # Server Callbacks
 
   @impl true
@@ -178,6 +213,36 @@ defmodule Orchard.SimulatorServer do
   @impl true
   def handle_call({:type_text, text}, _from, state) do
     result = type_text_on_simulator(state.udid, text)
+    {:reply, result, state}
+  end
+
+  @impl true
+  def handle_call({:tap_accessibility_id, accessibility_id, opts}, _from, state) do
+    result = perform_tap_accessibility_id(state.udid, accessibility_id, opts)
+    {:reply, result, state}
+  end
+
+  @impl true
+  def handle_call({:tap_label, label, opts}, _from, state) do
+    result = perform_tap_label(state.udid, label, opts)
+    {:reply, result, state}
+  end
+
+  @impl true
+  def handle_call({:swipe, start_x, start_y, end_x, end_y, opts}, _from, state) do
+    result = perform_swipe(state.udid, start_x, start_y, end_x, end_y, opts)
+    {:reply, result, state}
+  end
+
+  @impl true
+  def handle_call({:gesture, gesture_name, opts}, _from, state) do
+    result = perform_gesture(state.udid, gesture_name, opts)
+    {:reply, result, state}
+  end
+
+  @impl true
+  def handle_call({:button, button_name, opts}, _from, state) do
+    result = perform_button(state.udid, button_name, opts)
     {:reply, result, state}
   end
 
@@ -270,10 +335,12 @@ defmodule Orchard.SimulatorServer do
   end
 
   defp take_screenshot(udid, output_path) do
-    # Note: AXe doesn't have a screenshot command, we'll use simctl directly
-    case MuonTrap.cmd("xcrun", ["simctl", "io", udid, "screenshot", output_path]) do
-      {_, 0} -> :ok
-      {error, _} -> {:error, error}
+    # Use AXe screenshot command (available in 1.2.0+)
+    with :ok <- Downloader.ensure_available() do
+      case MuonTrap.cmd(Config.axe_cmd(), ["screenshot", "--udid", udid, "--output", output_path]) do
+        {_, 0} -> :ok
+        {error, _} -> {:error, "Failed to take screenshot: #{error}"}
+      end
     end
   end
 
@@ -327,6 +394,131 @@ defmodule Orchard.SimulatorServer do
         {error, _} ->
           {:error, error}
       end
+    end
+  end
+
+  defp perform_tap_accessibility_id(udid, accessibility_id, opts) do
+    with :ok <- Downloader.ensure_available() do
+      args = ["tap", "--udid", udid, "--id", accessibility_id]
+      args = add_delay_opts(args, opts)
+
+      case MuonTrap.cmd(Config.axe_cmd(), args) do
+        {_, 0} -> :ok
+        {error, _} -> {:error, "Failed to tap accessibility ID '#{accessibility_id}': #{error}"}
+      end
+    end
+  end
+
+  defp perform_tap_label(udid, label, opts) do
+    with :ok <- Downloader.ensure_available() do
+      args = ["tap", "--udid", udid, "--label", label]
+      args = add_delay_opts(args, opts)
+
+      case MuonTrap.cmd(Config.axe_cmd(), args) do
+        {_, 0} -> :ok
+        {error, _} -> {:error, "Failed to tap label '#{label}': #{error}"}
+      end
+    end
+  end
+
+  defp perform_swipe(udid, start_x, start_y, end_x, end_y, opts) do
+    with :ok <- Downloader.ensure_available() do
+      args = [
+        "swipe",
+        "--udid",
+        udid,
+        "--start-x",
+        to_string(start_x),
+        "--start-y",
+        to_string(start_y),
+        "--end-x",
+        to_string(end_x),
+        "--end-y",
+        to_string(end_y)
+      ]
+
+      args =
+        if duration = Keyword.get(opts, :duration) do
+          args ++ ["--duration", to_string(duration)]
+        else
+          args
+        end
+
+      args =
+        if delta = Keyword.get(opts, :delta) do
+          args ++ ["--delta", to_string(delta)]
+        else
+          args
+        end
+
+      args = add_delay_opts(args, opts)
+
+      case MuonTrap.cmd(Config.axe_cmd(), args) do
+        {_, 0} -> :ok
+        {error, _} -> {:error, "Failed to perform swipe: #{error}"}
+      end
+    end
+  end
+
+  defp perform_gesture(udid, gesture_name, opts) do
+    with :ok <- Downloader.ensure_available() do
+      args = ["gesture", to_string(gesture_name), "--udid", udid]
+
+      args =
+        if screen_width = Keyword.get(opts, :screen_width) do
+          args ++ ["--screen-width", to_string(screen_width)]
+        else
+          args
+        end
+
+      args =
+        if screen_height = Keyword.get(opts, :screen_height) do
+          args ++ ["--screen-height", to_string(screen_height)]
+        else
+          args
+        end
+
+      args = add_delay_opts(args, opts)
+
+      case MuonTrap.cmd(Config.axe_cmd(), args) do
+        {_, 0} -> :ok
+        {error, _} -> {:error, "Failed to perform gesture '#{gesture_name}': #{error}"}
+      end
+    end
+  end
+
+  defp perform_button(udid, button_name, opts) do
+    with :ok <- Downloader.ensure_available() do
+      args = ["button", to_string(button_name), "--udid", udid]
+
+      args =
+        if duration = Keyword.get(opts, :duration) do
+          args ++ ["--duration", to_string(duration)]
+        else
+          args
+        end
+
+      args = add_delay_opts(args, opts)
+
+      case MuonTrap.cmd(Config.axe_cmd(), args) do
+        {_, 0} -> :ok
+        {error, _} -> {:error, "Failed to press button '#{button_name}': #{error}"}
+      end
+    end
+  end
+
+  defp add_delay_opts(args, opts) do
+    args =
+      if pre_delay = Keyword.get(opts, :pre_delay) do
+        args ++ ["--pre-delay", to_string(pre_delay)]
+      else
+        args
+      end
+
+    if post_delay = Keyword.get(opts, :post_delay) do
+      args ++ ["--post-delay", to_string(post_delay)]
+    else
+      args
     end
   end
 end

--- a/lib/orchard/simulator_stream.ex
+++ b/lib/orchard/simulator_stream.ex
@@ -256,7 +256,7 @@ defmodule Orchard.SimulatorStream do
             {:args, args},
             :binary,
             :exit_status,
-            {:line, 65536}
+            {:line, 65_536}
           ])
 
         output_file = File.open!(output, [:write, :binary])

--- a/lib/orchard/simulator_stream.ex
+++ b/lib/orchard/simulator_stream.ex
@@ -2,21 +2,25 @@ defmodule Orchard.SimulatorStream do
   @moduledoc """
   Provides video capture capabilities for iOS simulators.
 
-  Since iOS simulators don't expose real-time video streams, this module provides
-  two approaches:
+  This module provides multiple approaches for video capture:
 
-  1. **Screenshot-based streaming**: Captures screenshots at intervals and encodes
-     them into a video stream. Good for basic use cases but has performance limitations.
+  1. **AXe stream-video** (v1.1.0+): Native video streaming at 1-30 FPS with multiple
+     output formats (MJPEG, raw JPEG, ffmpeg-compatible, BGRA).
 
-  2. **Window capture via FFmpeg**: Uses FFmpeg's AVFoundation to capture the
-     simulator window directly. Better performance but requires knowing the window title.
+  2. **AXe record-video** (v1.1.0+): Direct MP4 recording with H.264 encoding.
 
-  For production use cases requiring true real-time streaming, consider:
-  - Facebook's idb tool which can access the simulator's IOSurface
-  - Custom ScreenCaptureKit implementation (macOS 12.3+)
+  3. **Screenshot-based streaming**: Captures screenshots at intervals and encodes
+     them into a video stream. Legacy fallback approach.
+
+  4. **Window capture via FFmpeg**: Uses FFmpeg's AVFoundation to capture the
+     simulator window directly.
+
+  The AXe-based methods are recommended for better performance and reliability.
   """
 
   require Logger
+
+  alias Orchard.{Config, Downloader}
 
   @doc """
   Starts screenshot-based video streaming from a simulator.
@@ -191,8 +195,171 @@ defmodule Orchard.SimulatorStream do
   end
 
   @doc """
+  Starts video streaming using AXe's stream-video command.
+
+  Available since AXe 1.1.0. This provides native video streaming with multiple
+  output formats and better performance than screenshot-based approaches.
+
+  ## Options
+
+  - `:fps` - Frames per second, 1-30 (default: 10)
+  - `:format` - Output format: `:mjpeg`, `:raw`, `:ffmpeg`, `:bgra` (default: `:mjpeg`)
+  - `:output` - Output file path or stream destination (default: streams to stdout)
+
+  ## Formats
+
+  - `:mjpeg` - MJPEG format, suitable for direct playback
+  - `:raw` - Raw JPEG frames
+  - `:ffmpeg` - FFmpeg-compatible output for piping to ffmpeg
+  - `:bgra` - Legacy BGRA pixel format
+
+  ## Examples
+
+      # Stream to file in MJPEG format
+      {:ok, stream} = Orchard.SimulatorStream.start_axe_stream(udid, fps: 15, output: "stream.mjpeg")
+
+      # Stream for FFmpeg processing
+      {:ok, stream} = Orchard.SimulatorStream.start_axe_stream(udid, format: :ffmpeg, fps: 30)
+
+      # Stop the stream
+      Orchard.SimulatorStream.stop_capture(stream)
+  """
+  def start_axe_stream(simulator_udid, opts \\ []) do
+    with :ok <- Downloader.ensure_available() do
+      fps = Keyword.get(opts, :fps, 10)
+      format = Keyword.get(opts, :format, :mjpeg)
+      output = Keyword.get(opts, :output)
+
+      format_str =
+        case format do
+          :mjpeg -> "mjpeg"
+          :raw -> "raw"
+          :ffmpeg -> "ffmpeg"
+          :bgra -> "bgra"
+          other -> to_string(other)
+        end
+
+      args = [
+        "stream-video",
+        "--udid",
+        simulator_udid,
+        "--fps",
+        to_string(fps),
+        "--format",
+        format_str
+      ]
+
+      if output do
+        # Start as daemon writing to file
+        port =
+          Port.open({:spawn_executable, Config.axe_cmd()}, [
+            {:args, args},
+            :binary,
+            :exit_status,
+            {:line, 65536}
+          ])
+
+        output_file = File.open!(output, [:write, :binary])
+
+        # Start a task to read from port and write to file
+        task =
+          Task.async(fn ->
+            stream_to_file(port, output_file)
+          end)
+
+        {:ok, %{port: port, task: task, output: output, output_file: output_file, method: :axe_stream}}
+      else
+        # Start as daemon for raw output
+        case MuonTrap.Daemon.start_link(Config.axe_cmd(), args) do
+          {:ok, pid} ->
+            {:ok, %{pid: pid, method: :axe_stream}}
+
+          {:error, reason} ->
+            {:error, reason}
+        end
+      end
+    end
+  end
+
+  @doc """
+  Records video directly to MP4 using AXe's record-video command.
+
+  Available since AXe 1.1.0. This provides direct H.264 encoding to MP4 files
+  with configurable quality and scaling options.
+
+  ## Options
+
+  - `:fps` - Frames per second (default: 15)
+  - `:quality` - JPEG quality 1-100 (default: system default)
+  - `:scale` - Scale factor 0.0-1.0 (default: 1.0, full resolution)
+
+  ## Examples
+
+      # Start recording
+      {:ok, recording} = Orchard.SimulatorStream.start_axe_recording(udid, "output.mp4", fps: 20)
+
+      # Record with reduced quality for smaller file size
+      {:ok, recording} = Orchard.SimulatorStream.start_axe_recording(udid, "output.mp4",
+        fps: 10, quality: 60, scale: 0.5)
+
+      # Stop recording
+      Orchard.SimulatorStream.stop_capture(recording)
+  """
+  def start_axe_recording(simulator_udid, output_path, opts \\ []) do
+    with :ok <- Downloader.ensure_available() do
+      fps = Keyword.get(opts, :fps, 15)
+
+      args = [
+        "record-video",
+        "--udid",
+        simulator_udid,
+        "--fps",
+        to_string(fps),
+        "--output",
+        output_path
+      ]
+
+      args =
+        if quality = Keyword.get(opts, :quality) do
+          args ++ ["--quality", to_string(quality)]
+        else
+          args
+        end
+
+      args =
+        if scale = Keyword.get(opts, :scale) do
+          args ++ ["--scale", to_string(scale)]
+        else
+          args
+        end
+
+      case MuonTrap.Daemon.start_link(Config.axe_cmd(), args) do
+        {:ok, pid} ->
+          {:ok, %{pid: pid, output: output_path, method: :axe_record}}
+
+        {:error, reason} ->
+          {:error, reason}
+      end
+    end
+  end
+
+  @doc """
   Stops a video capture/recording process.
   """
+  def stop_capture(%{port: port, output_file: output_file} = capture) when is_port(port) do
+    Port.close(port)
+
+    if output_file do
+      File.close(output_file)
+    end
+
+    if task = Map.get(capture, :task) do
+      Task.shutdown(task, :brutal_kill)
+    end
+
+    :ok
+  end
+
   def stop_capture(%{port: port}) when is_port(port) do
     Port.close(port)
     :ok
@@ -206,6 +373,31 @@ defmodule Orchard.SimulatorStream do
   def stop_capture(%{task: task}) do
     Task.shutdown(task, :brutal_kill)
     :ok
+  end
+
+  defp stream_to_file(port, output_file) do
+    receive do
+      {^port, {:data, {:eol, data}}} ->
+        IO.binwrite(output_file, data)
+        IO.binwrite(output_file, "\n")
+        stream_to_file(port, output_file)
+
+      {^port, {:data, {:noeol, data}}} ->
+        IO.binwrite(output_file, data)
+        stream_to_file(port, output_file)
+
+      {^port, {:data, data}} when is_binary(data) ->
+        IO.binwrite(output_file, data)
+        stream_to_file(port, output_file)
+
+      {^port, {:exit_status, _status}} ->
+        File.close(output_file)
+        :ok
+
+      {^port, :closed} ->
+        File.close(output_file)
+        :ok
+    end
   end
 
   # Private functions

--- a/lib/orchard/simulator_stream.ex
+++ b/lib/orchard/simulator_stream.ex
@@ -267,7 +267,8 @@ defmodule Orchard.SimulatorStream do
             stream_to_file(port, output_file)
           end)
 
-        {:ok, %{port: port, task: task, output: output, output_file: output_file, method: :axe_stream}}
+        {:ok,
+         %{port: port, task: task, output: output, output_file: output_file, method: :axe_stream}}
       else
         # Start as daemon for raw output
         case MuonTrap.Daemon.start_link(Config.axe_cmd(), args) do

--- a/priv/axe/versions.json
+++ b/priv/axe/versions.json
@@ -1,4 +1,44 @@
 {
+  "1.2.1": {
+    "macOS-arm64": {
+      "url": "https://github.com/cameroncooke/AXe/releases/download/v1.2.1/AXe-macOS-v1.2.1.tar.gz",
+      "checksum": null
+    },
+    "macOS-x86_64": {
+      "url": "https://github.com/cameroncooke/AXe/releases/download/v1.2.1/AXe-macOS-v1.2.1.tar.gz",
+      "checksum": null
+    }
+  },
+  "1.2.0": {
+    "macOS-arm64": {
+      "url": "https://github.com/cameroncooke/AXe/releases/download/v1.2.0/AXe-macOS-v1.2.0.tar.gz",
+      "checksum": null
+    },
+    "macOS-x86_64": {
+      "url": "https://github.com/cameroncooke/AXe/releases/download/v1.2.0/AXe-macOS-v1.2.0.tar.gz",
+      "checksum": null
+    }
+  },
+  "1.1.1": {
+    "macOS-arm64": {
+      "url": "https://github.com/cameroncooke/AXe/releases/download/v1.1.1/AXe-macOS-v1.1.1.tar.gz",
+      "checksum": null
+    },
+    "macOS-x86_64": {
+      "url": "https://github.com/cameroncooke/AXe/releases/download/v1.1.1/AXe-macOS-v1.1.1.tar.gz",
+      "checksum": null
+    }
+  },
+  "1.1.0": {
+    "macOS-arm64": {
+      "url": "https://github.com/cameroncooke/AXe/releases/download/v1.1.0/AXe-macOS-v1.1.0.tar.gz",
+      "checksum": null
+    },
+    "macOS-x86_64": {
+      "url": "https://github.com/cameroncooke/AXe/releases/download/v1.1.0/AXe-macOS-v1.1.0.tar.gz",
+      "checksum": null
+    }
+  },
   "1.0.0": {
     "macOS-arm64": {
       "url": "https://github.com/cameroncooke/AXe/releases/download/v1.0.0/AXe-macOS-v1.0.0.tar.gz",


### PR DESCRIPTION
## Summary

- Update bundled AXe CLI from v1.0.0 to v1.2.1
- Add support for all intermediate versions (1.1.0, 1.1.1, 1.2.0)
- Expose new AXe capabilities through the Elixir API

### New capabilities from AXe 1.2.0+

| Function | Description |
|----------|-------------|
| `Simulator.tap_accessibility_id/3` | Tap elements by accessibility ID (more reliable than coordinates) |
| `Simulator.tap_label/3` | Tap elements by accessibility label |
| `Simulator.screenshot/2` | Now uses AXe's native screenshot command |

### New capabilities from AXe 1.1.0+

| Function | Description |
|----------|-------------|
| `Simulator.stream_video/2` | Native video streaming (MJPEG, raw, ffmpeg, BGRA formats) |
| `Simulator.record_video_axe/3` | Direct MP4 recording with H.264 encoding |

### Additional UI automation features

| Function | Description |
|----------|-------------|
| `Simulator.swipe/6` | Custom swipe gestures with duration/delta options |
| `Simulator.gesture/3` | Preset gestures (scroll_up, scroll_down, edge swipes) |
| `Simulator.button/3` | Hardware button simulation (home, lock, siri, apple_pay) |

## Test plan

- [ ] Verify AXe 1.2.1 downloads correctly
- [ ] Test tap_accessibility_id with a booted simulator
- [ ] Test tap_label with a booted simulator
- [ ] Test gesture commands (scroll_down, swipe_from_left_edge)
- [ ] Test button commands (home, lock)
- [ ] Test video streaming with stream_video
- [ ] Test video recording with record_video_axe

🤖 Generated with [Claude Code](https://claude.com/claude-code)